### PR TITLE
Expand the critial section of the readers/writers.

### DIFF
--- a/performance/single-node/lock_tests.c
+++ b/performance/single-node/lock_tests.c
@@ -54,9 +54,6 @@ static pthread_barrier_t barrier;
 static pthread_t *writers, *readers;
 static lock_t lock;
 
-/* dummy write/read var. */
-static volatile int np;
-
 /*******************************************************************************
  * Begin test functions
  ******************************************************************************/
@@ -71,9 +68,7 @@ void *reader(void *arg)
 
 	for (i = 0; i < nreads; i++) {
 		rlock_acquire(&lock);
-		p = np;
-		assert(p == np);
-		while (++tmp % 128);
+		while (++tmp % 64);
 		release(&lock);
 	}
 
@@ -83,12 +78,15 @@ void *reader(void *arg)
 void *writer(void *arg)
 {
 	unsigned nwrites = *(unsigned *) arg, i;
+	volatile int tmp = 0;
+
 	pthread_barrier_wait(&barrier);
 	ct_start_clock();
 
+
 	for (i = 0; i < nwrites; i++) {
 		rwlock_acquire(&lock);
-		while (++np % 128);
+		while (++tmp % 128);
 		release(&lock);
 	}
 


### PR DESCRIPTION
- Added volatile writes to both the readers and writers.

@hppritcha @ztiffany @jswaro @jshimek @tonyzinger @chuckfossen @sungeunchoi here are some results from these updated tests.
[lock-tests-glibc-2.11.3-2r-2w-2to20rw.pdf](https://github.com/ofi-cray/cray-tests/files/362051/lock-tests-glibc-2.11.3-2r-2w-2to20rw.pdf)
[lock-tests-glibc-2.11.3-128r-128w-2to14rw.pdf](https://github.com/ofi-cray/cray-tests/files/362054/lock-tests-glibc-2.11.3-128r-128w-2to14rw.pdf)

Edit: These results were collected using 9ab2c72.

Comparing the results above to #22 it appears that mutexes are an optimal choice when there is _very_ _little_ IO/CPU work going on in the critical section, how little work will not be clear without further testing.

As shown by the results listed above in this PR, rwlocks appear to perform better when there are _more_ IO/CPU intensive operations within the critical section.
