### PR TITLE
Add perftools profiling library to configure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,8 +58,14 @@ AM_CFLAGS += -lpmi
 if HAVE_CRAY_PMI
 AM_CFLAGS += -DCRAY_PMI_COLL
 endif
-
 endif
 
+if HAVE_PROFILE
+AM_CFLAGS += -lprofiler
+
+if HAVE_CPUPROFILE
+AM_CFLAGS += -DCPUPROFILE_ENABLED
+endif
+endif
 # test:
 #	./scripts/run_craytests.sh

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,19 @@ AC_CHECK_LIB([pmi], [PMI_Allgather],
 	     AM_CONDITIONAL([HAVE_CRAY_PMI], [true]),
 	     AM_CONDITIONAL([HAVE_CRAY_PMI], [false]))
 
+AC_ARG_WITH([profiler],
+            AC_HELP_STRING([--with-profiler], [Specify libprofiler location - default NO]),
+            [AS_IF([test -d $withval/lib64], [profiler_libdir="lib64"], [profiler_libdir="lib"])
+             CPPFLAGS="-I $withval/include $CPPFLAGS"
+             LDFLAGS="-L$withval/$profiler_libdir $LDFLAGS"
+             AM_CONDITIONAL([HAVE_PROFILE], [true])],
+            [AM_CONDITIONAL([HAVE_PROFILE], [false])])
+
+AC_CHECK_LIB([profiler], [ProfilerStart],
+	     AM_CONDITIONAL([HAVE_CPUPROFILE], [true]),
+	     AM_CONDITIONAL([HAVE_CPUPROFILE], [false]))
+
+
 dnl Checks for libraries
 AC_CHECK_LIB([fabric], fi_getinfo, [],
     AC_MSG_ERROR([fi_getinfo() not found.  cray-tests requires libfabric.]))


### PR DESCRIPTION
Added configure time parameters to add support for Google
Perftools in the repo. This is an optional feature.

Signed-off-by: James Swaro jswaro@cray.com

@sungeunchoi @hppritcha 
