### PR TITLE
Fix extraneous \n issue in rdm_mbw_mr

### DIFF
--- a/performance/multi-node/rdm_mbw_mr.c
+++ b/performance/multi-node/rdm_mbw_mr.c
@@ -758,8 +758,8 @@ int main(int argc, char *argv[])
 								FIELD_WIDTH, c + 1, FLOAT_PRECISION, bw);
 							fflush(stdout);
 						}
+						fprintf(stdout, c == IOV_CNT - 1 ? "\n" : "");
 					}
-					fprintf(stdout, c == IOV_CNT - 1 ? "\n" : "");
 				}
 			}
 		}


### PR DESCRIPTION
Moved the print of the \n to inside the if
check so we only add a newline when data has
been printed for a test.

Fixes #45 
@sungeunchoi @jswaro @ztiffany 
Signed-off-by: James Shimek <jshimek@cray.com>