### PR TITLE
Deregister memory prior to free in random_access

### DIFF
--- a/performance/multi-node/random_access.c
+++ b/performance/multi-node/random_access.c
@@ -889,6 +889,15 @@ static int random_access(void)
 	}
 	/* End verification phase */
 
+	rc = fi_close(&prov.data.l_lock_mr->fid);
+	assert(rc == FI_SUCCESS);
+	
+	rc = fi_close(&prov.data.l_table_mr->fid);
+	assert(rc == FI_SUCCESS);
+
+	rc = fi_close(&prov.data.l_scratch_mr->fid);
+	assert(rc == FI_SUCCESS);
+
 	free(hpcc_table);
 	free(hpcc_lock);
 	failed_table:


### PR DESCRIPTION
Several warnings were being thrown about registered memory including
unmapped pages. This commit fixes the problem by deregistering the memory
prior to calling free. There isn't a functional issue as the warnings
are present to allow the user to know they freed the memory prior to
deregistering it.

Signed-off-by: James Swaro <jswaro@cray.com>

closes #44 

@sungeunchoi 