### PR TITLE
performance/multi-node: use fi_inject_write.

### DIFF
--- a/performance/multi-node/rdm_one_sided.c
+++ b/performance/multi-node/rdm_one_sided.c
@@ -143,7 +143,7 @@ void print_usage(void)
 		ct_print_opts_usage("-l <loops>", "number of loops to measure");
 		ct_print_opts_usage("-s <skip>", "number of loops to skip");
 		ct_print_opts_usage("-i <iterations>", "iterations per loop");
-		ct_print_opts_usage("-j", "use fi_inject_write");
+		ct_print_opts_usage("-n", "use fi_inject_write");
 		ct_print_std_usage();
 	}
 }
@@ -639,7 +639,7 @@ int main(int argc, char *argv[])
 		return -1;
 	}
 
-	while ((op = getopt(argc, argv, "hmt:i:l:s:j" CT_STD_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "hmt:i:l:s:n" CT_STD_OPTS)) != -1) {
 		switch (op) {
 		default:
 			ct_parse_std_opts(op, optarg, hints);
@@ -684,7 +684,7 @@ int main(int argc, char *argv[])
 			}
 			window_size_large = window_size;
 			break;
-		case 'j':
+		case 'n':
 			use_fi_inject_write = ~0;
 			break;
 		case '?':

--- a/performance/multi-node/rdm_one_sided.c
+++ b/performance/multi-node/rdm_one_sided.c
@@ -534,6 +534,85 @@ void *thread_fn(void *data)
 	return NULL;
 }
 
+void *thread_fn_inject(void *data)
+{
+	int i, j, peer;
+	int size;
+	ssize_t __attribute__((unused)) fi_rc;
+	struct per_thread_data *ptd;
+	struct per_iteration_data it;
+	uint64_t t_start = 0, t_end = 0;
+
+	it.data = data;
+	size = it.message_size;
+
+	if (it.thread_id >= tunables.threads)
+		return (void *)-EINVAL;
+
+	ptd = &thread_data[it.thread_id];
+	ptd->bytes_sent = 0;
+
+	ct_tbarrier(&ptd->tbar);
+
+	if (myid == 0) {
+		peer = 1;
+
+		for (i = 0; i < loop + skip; i++) {
+			if (i == skip) {  /* warm up loop */
+				t_start = get_time_usec();
+				ptd->bytes_sent = 0;
+			}
+
+			for (j = 0; j < window_size; j++) {
+				fi_rc = fi_inject_write(ptd->ep,
+							ptd->s_buf,
+							size,
+							ptd->fi_addrs[peer],
+							ptd->rbuf_descs[peer].addr,
+							ptd->rbuf_descs[peer].key);
+				assert(fi_rc==FI_SUCCESS);
+				ptd->bytes_sent += size;
+			}
+		}
+
+		fi_rc = fi_send(ptd->ep, ptd->s_buf, 4, NULL,
+				ptd->fi_addrs[peer],
+				NULL);
+		assert(!fi_rc);
+		wait_for_comp(ptd->scq, 1);
+
+		fi_rc = fi_recv(ptd->ep, ptd->s_buf, 4, NULL,
+				ptd->fi_addrs[peer],
+				NULL);
+		assert(!fi_rc);
+		wait_for_comp(ptd->rcq, 1);
+
+		t_end = get_time_usec();
+	} else if (myid == 1) {
+		peer = 0;
+
+		fi_rc = fi_recv(ptd->ep, ptd->s_buf, 4, NULL,
+				ptd->fi_addrs[peer],
+				NULL);
+		assert(!fi_rc);
+		wait_for_comp(ptd->rcq, 1);
+
+		fi_rc = fi_send(ptd->ep, ptd->s_buf, 4, NULL,
+				ptd->fi_addrs[peer],
+				NULL);
+		assert(!fi_rc);
+		wait_for_comp(ptd->scq, 1);
+	}
+
+	ct_tbarrier(&ptd->tbar);
+
+	ptd->latency = (t_end - t_start) / (double)(loop * window_size);
+	ptd->time_start = t_start;
+	ptd->time_end = t_end;
+
+	return NULL;
+}
+
 int main(int argc, char *argv[])
 {
 	int op, ret;
@@ -683,7 +762,8 @@ int main(int argc, char *argv[])
 		for (i = 0; i < tunables.threads; i++) {
 			iter_key.thread_id = i;
 			ret = pthread_create(&thread_data[i].thread, NULL,
-					thread_fn, iter_key.data);
+					size <= fi->tx_attr->inject_size ?
+			thread_fn_inject : thread_fn, iter_key.data);
 			if (ret != 0) {
 				printf("couldn't create thread %i\n", i);
 				pthread_exit(NULL); /* a more robust exit would be nice here */


### PR DESCRIPTION
- Use fi_write_inject until the inject threshold is exceeded.
- This is to compare the performance of fi_inject_write to fi_write.

With the changes introduced in this PR we get:

at https://github.com/ofi-cray/libfabric-cray/tree/6cdc8c283feecc2b3b881666598edcf96dd56d5e:
```
bin$ aprun --network -n2 -t960 -N1 -d1 ./rdm_one_sided -t1
1 threads
# Libfabric Bandwidth Test 
# Size        Bandwidth (MB/s)        Latency (us)        Min Lat (us)        Max Lat (us)
1                         0.24                4.00                4.00                4.00
2                         0.48                3.94                3.94                3.94
4                         0.98                3.90                3.90                3.90
8                         1.94                3.93                3.93                3.93
16                        3.86                3.96                3.96                3.96
32                        7.77                3.93                3.93                3.93
64                       15.49                3.94                3.94                3.94
128                     164.02                0.74                0.74                0.74
256                     326.45                0.75                0.75                0.75
512                     637.01                0.77                0.77                0.77
1024                   1197.02                0.82                0.82                0.82
2048                   1835.43                1.06                1.06                1.06
4096                   2505.19                1.56                1.56                1.56
8192                   5972.43                1.31                1.31                1.31
16384                  7291.29                2.14                2.14                2.14
32768                  8238.93                3.79                3.79                3.79
65536                  8819.31                7.09                7.09                7.09
131072                 9120.97               13.70               13.70               13.70
262144                 9306.11               26.86               26.86               26.86
524288                 9385.54               53.27               53.27               53.27
1048576                9447.40              105.85              105.85              105.85
2097152                9464.41              211.32              211.32              211.32
4194304                9411.90              424.99              424.99              424.99
```

and at https://github.com/ofi-cray/libfabric-cray/tree/2b63528292d4ead86c120f134edfc6ccb25f8369:
```
bin$ aprun --network -n2 -t960 -N1 -d1 ./rdm_one_sided -t1
1 threads
# Libfabric Bandwidth Test 
# Size        Bandwidth (MB/s)        Latency (us)        Min Lat (us)        Max Lat (us)
1                         0.82                1.16                1.16                1.16
2                         0.76                2.51                2.51                2.51
4                         4.48                0.85                0.85                0.85
8                        10.52                0.73                0.73                0.73
16                       20.30                0.75                0.75                0.75
32                       36.63                0.83                0.83                0.83
64                       80.39                0.76                0.76                0.76
128                     167.08                0.73                0.73                0.73
256                     332.01                0.74                0.74                0.74
512                     646.42                0.76                0.76                0.76
1024                   1213.19                0.80                0.80                0.80
2048                   1855.98                1.05                1.05                1.05
4096                   2527.70                1.55                1.55                1.55
8192                   5931.69                1.32                1.32                1.32
16384                  7280.67                2.15                2.15                2.15
32768                  8230.45                3.80                3.80                3.80
65536                  8804.75                7.10                7.10                7.10
131072                 9099.18               13.74               13.74               13.74
262144                 9301.24               26.88               26.88               26.88
524288                 9400.84               53.19               53.19               53.19
1048576                9407.68              106.30              106.30              106.30
2097152                9448.38              211.68              211.68              211.68
4194304                9426.98              424.31              424.31              424.31
```

Signed-off-by: Evan Harvey <eharvey@lanl.gov>