### PR TITLE
fixes to build cray-tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,10 +64,6 @@ EXTRA_DIST = \
 
 if HAVE_PMI
 AM_CFLAGS += -lpmi
-
-if HAVE_CRAY_PMI
-AM_CFLAGS += -DCRAY_PMI_COLL
-endif
 endif
 
 if HAVE_PROFILE

--- a/common/ct_utils.c
+++ b/common/ct_utils.c
@@ -54,8 +54,9 @@
 #include <rdma/fi_rma.h>
 #include "ct_utils.h"
 #include "pmi.h"
+#include "config.h"
 
-#ifndef CRAY_PMI_COLL
+#if !HAVE_CRAY_PMI_COLL
 
 static int myRank;
 static char *kvsName;

--- a/configure.ac
+++ b/configure.ac
@@ -55,8 +55,8 @@ AC_ARG_WITH([pmi],
             [AM_CONDITIONAL([HAVE_PMI], [false])])
 
 AC_CHECK_LIB([pmi], [PMI_Allgather],
-	     AM_CONDITIONAL([HAVE_CRAY_PMI], [true]),
-	     AM_CONDITIONAL([HAVE_CRAY_PMI], [false]))
+	     [AC_DEFINE_UNQUOTED([HAVE_CRAY_PMI_COLL], [1], [define to 1 if Cray PMI collectives present])],
+	     [AC_DEFINE_UNQUOTED([HAVE_CRAY_PMI_COLL], [0], [define to 1 if Cray PMI collectives present])])
 
 AC_ARG_WITH([profiler],
             AC_HELP_STRING([--with-profiler], [Specify libprofiler location - default NO]),
@@ -84,7 +84,7 @@ AC_MSG_CHECKING([for fi_trywait support])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <rdma/fi_eq.h>]],
 	       [[fi_trywait(NULL, NULL, 0);]])],
 	       [AC_MSG_RESULT([yes])],
-	       [AC_MSG_RESULT([no])
+		[AC_MSG_RESULT([no])
 	        AC_MSG_ERROR([cray-tests requires fi_trywait support. Cannot continue])])
 
 AC_CONFIG_FILES([Makefile])


### PR DESCRIPTION
Absolutely no idea how this stuff was working before,
but at least on CLE 6, the prior configure/makefile
setup totally failed owing to Cray PMI related problems.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>